### PR TITLE
[_] feat: delete file versions when a file is marked as DELETED

### DIFF
--- a/src/drive.ts
+++ b/src/drive.ts
@@ -183,4 +183,54 @@ export class DriveDatabase {
       count = result.rowCount;
     } while (count === 1000);
   }
+
+      /**
+     * Gets network file IDs for existing file versions in batches
+     * @param fileIds
+     */
+    async getFileVersionsByFileId(fileIds: string[]): Promise<
+        {
+            id: string;
+            fileId: string;
+            networkFileId: string;
+        }[]
+    > {
+        const placeholders = fileIds.map((_, i) => `$${i + 1}`).join(", ");
+        const query = `
+            SELECT network_file_id, file_id, id
+            FROM file_versions
+            WHERE file_id IN (${placeholders})
+            AND status = 'EXISTS'
+        `;
+
+        const result = await this.client.query(query, fileIds);
+
+        return result.rows.map((r) => ({
+            id: r.id,
+            networkFileId: r.network_file_id,
+            fileId: r.file_id,
+        }));
+    }
+
+
+    /**
+     * Mark file versions as deleted
+     * @param versionIds
+     */
+    async markFileVersionsAsDeleted(versionIds: string[]): Promise<number> {
+        const placeholders = versionIds.map((_, i) => `$${i + 1}`).join(", ");
+        if (placeholders.length === 0) {
+            return 0;
+        }
+
+        const query = `
+            UPDATE file_versions
+            SET status = 'DELETED', updated_at = NOW()
+            WHERE id IN (${placeholders})
+            AND status = 'EXISTS'
+        `;
+        const result = await this.client.query(query, versionIds);
+
+        return result.rowCount;
+    }
 }

--- a/src/tasks/file-deletion/index.ts
+++ b/src/tasks/file-deletion/index.ts
@@ -123,7 +123,7 @@ const task: TaskFunction = async (
           const res = await deleteFiles(process.env.NETWORK_GATEWAY_DELETE_FILES_ENDPOINT as string, aggregatedNetworkFileIdsToDelete);
           const fileIdsDeletedSuccesfully = res.message.confirmed;
           const filesToMarkAsDeleted = task.payload.filter((file) => fileIdsDeletedSuccesfully.includes(file.networkFileId));
-          const fileVersionsToMarkAsDeleted = fileVersionsData.filter((fileNetwork) => fileIdsDeletedSuccesfully.includes(fileNetwork.networkFileId));
+          const fileVersionsToMarkAsDeleted = fileVersionsData.filter((fileVersion) => fileIdsDeletedSuccesfully.includes(fileVersion.networkFileId));
 
           await drive.db.markDeletedFilesAsProcessed(filesToMarkAsDeleted.map(f => f.fileId));
           await drive.db.markFileVersionsAsDeleted(fileVersionsToMarkAsDeleted.map(fv => fv.id));

--- a/src/tasks/file-deletion/index.ts
+++ b/src/tasks/file-deletion/index.ts
@@ -114,11 +114,19 @@ const task: TaskFunction = async (
           logger.log(`received item: + ${JSON.stringify(task)}`, 'consumer');
 
           const networkFileIdsToDelete = task.payload.map((file) => file.networkFileId);
-          const res = await deleteFiles(process.env.NETWORK_GATEWAY_DELETE_FILES_ENDPOINT as string, networkFileIdsToDelete);
+          const fileIdsToDelete = task.payload.map((file) => file.fileId);
+          const fileVersionsData = await drive.db.getFileVersionsByFileId(fileIdsToDelete);
+          const networkVersionFileIdsToDelete = fileVersionsData.map(fv => fv.networkFileId);
+
+          const aggregatedNetworkFileIdsToDelete = networkFileIdsToDelete.concat(networkVersionFileIdsToDelete);
+        
+          const res = await deleteFiles(process.env.NETWORK_GATEWAY_DELETE_FILES_ENDPOINT as string, aggregatedNetworkFileIdsToDelete);
           const fileIdsDeletedSuccesfully = res.message.confirmed;
           const filesToMarkAsDeleted = task.payload.filter((file) => fileIdsDeletedSuccesfully.includes(file.networkFileId));
+          const fileVersionsToMarkAsDeleted = fileVersionsData.filter((fileNetwork) => fileIdsDeletedSuccesfully.includes(fileNetwork.networkFileId));
 
           await drive.db.markDeletedFilesAsProcessed(filesToMarkAsDeleted.map(f => f.fileId));
+          await drive.db.markFileVersionsAsDeleted(fileVersionsToMarkAsDeleted.map(fv => fv.id));
         },
         maxConcurrentItems ? parseInt(maxConcurrentItems as string) : undefined,
       );


### PR DESCRIPTION
We are implementing files versioning, however, when files get marked as DELETED by the background process we need to also remove their versions as they use space in the user's network.

### Changes
- Added delete versions of deleted files in the consumer of the queue
- Added a SELECT to get the file versions by file uuid (file_id in the version's domain)
- Added UPDATE to update file versions according to their Id

We already have the required indexes to make this query performant so no migration in drive-server-wip is required.

Explain analyze:

```
Bitmap Heap Scan on file_versions  (cost=132.21..597.16 rows=9330 width=60) (actual time=0.241..1.635 rows=9353 loops=1)
  Recheck Cond: ((file_id = ANY ('{97c0d232-289f-465b-9f78-312c6aa5e59f,d157f3da-144b-413b-9860-2fce7efdb28c}'::uuid[])) AND (status = 'EXISTS'::enum_file_versions_status))
  Heap Blocks: exact=257
  ->  Bitmap Index Scan on file_versions_file_id_status  (cost=0.00..129.88 rows=9330 width=0) (actual time=0.206..0.206 rows=9353 loops=1)
        Index Cond: ((file_id = ANY ('{97c0d232-289f-465b-9f78-312c6aa5e59f,d157f3da-144b-413b-9860-2fce7efdb28c}'::uuid[])) AND (status = 'EXISTS'::enum_file_versions_status))
Planning Time: 0.098 ms
Execution Time: 2.015 ms
```