### PR TITLE
[PB-5704] refactor/mark versions as removed

### DIFF
--- a/src/drive.ts
+++ b/src/drive.ts
@@ -214,10 +214,10 @@ export class DriveDatabase {
 
 
     /**
-     * Mark file versions as deleted
+     * Mark file versions as removed
      * @param versionIds
      */
-    async markFileVersionsAsDeleted(versionIds: string[]): Promise<number> {
+    async markFileVersionsAsRemoved(versionIds: string[]): Promise<number> {
         const placeholders = versionIds.map((_, i) => `$${i + 1}`).join(", ");
         if (placeholders.length === 0) {
             return 0;
@@ -225,9 +225,8 @@ export class DriveDatabase {
 
         const query = `
             UPDATE file_versions
-            SET status = 'DELETED', updated_at = NOW()
+            SET status = 'REMOVED', updated_at = NOW()
             WHERE id IN (${placeholders})
-            AND status = 'EXISTS'
         `;
         const result = await this.client.query(query, versionIds);
 

--- a/src/tasks/file-deletion/index.ts
+++ b/src/tasks/file-deletion/index.ts
@@ -126,7 +126,7 @@ const task: TaskFunction = async (
           const fileVersionsToMarkAsDeleted = fileVersionsData.filter((fileVersion) => fileIdsDeletedSuccesfully.includes(fileVersion.networkFileId));
 
           await drive.db.markDeletedFilesAsProcessed(filesToMarkAsDeleted.map(f => f.fileId));
-          await drive.db.markFileVersionsAsDeleted(fileVersionsToMarkAsDeleted.map(fv => fv.id));
+          await drive.db.markFileVersionsAsRemoved(fileVersionsToMarkAsDeleted.map(fv => fv.id));
         },
         maxConcurrentItems ? parseInt(maxConcurrentItems as string) : undefined,
       );


### PR DESCRIPTION
In `drive-server-wip`, file versions are marked as soft-deleted (`DELETED`) in several scenarios (max versions exceeded, retention expired, manual deletion, plan downgrade). However, these versions remain in the storage network (Storj). A background process will query versions with `DELETED` status, remove them from the network, and update their status to `REMOVED`. This allows discriminating which versions are pending cleanup, and the count of `DELETED` versions will tend to zero as the process runs.

  ### Changes
  - Renamed `markFileVersionsAsDeleted` to `markFileVersionsAsRemoved`
  - Changed status update from `DELETED` to `REMOVED`
  - Removed redundant `AND status = 'EXISTS'` condition (already filtered in `getFileVersionsByFileId`)
