### PR TITLE
[_] refactor(delete-files): remove version deletion from network

### DIFF
--- a/src/tasks/file-deletion/index.ts
+++ b/src/tasks/file-deletion/index.ts
@@ -115,18 +115,15 @@ const task: TaskFunction = async (
 
           const networkFileIdsToDelete = task.payload.map((file) => file.networkFileId);
           const fileIdsToDelete = task.payload.map((file) => file.fileId);
+
+          const res = await deleteFiles(process.env.NETWORK_GATEWAY_DELETE_FILES_ENDPOINT as string, networkFileIdsToDelete);
+          const fileIdsDeletedSuccessfully = res.message.confirmed;
+          const filesToMarkAsProcessed = task.payload.filter((file) => fileIdsDeletedSuccessfully.includes(file.networkFileId));
+
+          await drive.db.markDeletedFilesAsProcessed(filesToMarkAsProcessed.map(f => f.fileId));
+
           const fileVersionsData = await drive.db.getFileVersionsByFileId(fileIdsToDelete);
-          const networkVersionFileIdsToDelete = fileVersionsData.map(fv => fv.networkFileId);
-
-          const aggregatedNetworkFileIdsToDelete = networkFileIdsToDelete.concat(networkVersionFileIdsToDelete);
-        
-          const res = await deleteFiles(process.env.NETWORK_GATEWAY_DELETE_FILES_ENDPOINT as string, aggregatedNetworkFileIdsToDelete);
-          const fileIdsDeletedSuccesfully = res.message.confirmed;
-          const filesToMarkAsDeleted = task.payload.filter((file) => fileIdsDeletedSuccesfully.includes(file.networkFileId));
-          const fileVersionsToMarkAsDeleted = fileVersionsData.filter((fileVersion) => fileIdsDeletedSuccesfully.includes(fileVersion.networkFileId));
-
-          await drive.db.markDeletedFilesAsProcessed(filesToMarkAsDeleted.map(f => f.fileId));
-          await drive.db.markFileVersionsAsDeleted(fileVersionsToMarkAsDeleted.map(fv => fv.id));
+          await drive.db.markFileVersionsAsDeleted(fileVersionsData.map(fv => fv.id));
         },
         maxConcurrentItems ? parseInt(maxConcurrentItems as string) : undefined,
       );


### PR DESCRIPTION
The delete-files consumer currently deletes both main files and their versions from the Storj network. However, file versions can be marked as DELETED through multiple paths (retention policies, plan downgrades, manual deletion) without the parent file being deleted. These orphaned versions are never physically removed from storage.

This refactor separates file deletion from version deletion. The delete-files consumer now only deletes main files from the network and marks associated versions as DELETED in the database. A dedicated delete-file-versions task (to be implemented) will handle physical deletion of all versions marked as DELETED, regardless of how they were marked.

  ### Changes
  - Consumer deletes ONLY main files from Storj network (not versions)
  - Associated file versions are marked as DELETED in database (soft delete)
  - Removed concatenation of file IDs + version IDs for network deletion
  