### PR TITLE
[_] refactor/extract network module

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -1,0 +1,38 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { sign } from 'jsonwebtoken';
+
+export type DeleteFilesResponse = {
+  message: {
+    confirmed: string[],
+    notConfirmed: string[]
+  }
+}
+
+export function signToken(duration: string, secret: string): string {
+  return sign(
+    {},
+    Buffer.from(secret, 'base64').toString('utf8'),
+    {
+      algorithm: 'RS256',
+      expiresIn: duration
+    }
+  );
+}
+
+export function deleteFiles(endpoint: string, fileIds: string[]): Promise<DeleteFilesResponse> {
+  const params: AxiosRequestConfig = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${signToken(
+        '5m',
+        process.env.NETWORK_GATEWAY_DELETE_FILES_SECRET as string
+      )}`
+    },
+    data: {
+      files: fileIds
+    }
+  };
+
+  return axios.delete<DeleteFilesResponse>(endpoint, params)
+    .then((res) => res.data);
+}

--- a/src/tasks/file-deletion/index.ts
+++ b/src/tasks/file-deletion/index.ts
@@ -1,12 +1,11 @@
 import { v4 } from 'uuid';
-import axios, { AxiosRequestConfig } from 'axios';
-import { sign } from 'jsonwebtoken'
 
 import { createLogger } from '../../utils';
 import { Consumer } from '../../consumer';
 import { Producer } from '../../producer';
 import { DeletedFilesIterator } from './deleted-files.iterator';
 import { TaskFunction } from '../task';
+import { deleteFiles } from '../../network';
 
 const task: TaskFunction = async (
   processType,
@@ -15,42 +14,6 @@ const task: TaskFunction = async (
 ) => {
   const processId = v4();
   const logger = createLogger(processId);
-
-  type DeleteFilesResponse = {
-    message: {
-      confirmed: string[],
-      notConfirmed: string[]
-    }
-  }
-
-  function signToken(duration: string, secret: string) {
-    return sign(
-      {},
-      Buffer.from(secret, 'base64').toString('utf8'),
-      {
-        algorithm: 'RS256',
-        expiresIn: duration
-      }
-    );
-  }
-
-  function deleteFiles(endpoint: string, fileIds: string[]): Promise<DeleteFilesResponse> {
-    const params: AxiosRequestConfig = {
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${signToken(
-          '5m', 
-          process.env.NETWORK_GATEWAY_DELETE_FILES_SECRET as string
-        )}`
-      },
-      data: {
-        files: fileIds
-      }
-    };
-
-    return axios.delete<DeleteFilesResponse>(endpoint, params)
-      .then((res) => res.data);
-  }
 
   const queueName = `${process.env.TASK_TYPE}-${process.env.NODE_ENV}`;
   const maxEnqueuedItems = process.env.TASK_DELETE_FILES_PRODUCER_MAX_ENQUEUED_ITEMS;


### PR DESCRIPTION
The network deletion logic (JWT signing and file deletion via Network Gateway) was duplicated in the `delete-files` task. With the upcoming `delete-file-versions` task, this duplication would increase further.

This refactor extracts the common network deletion logic into a shared `src/network.ts` module, making it reusable across all deletion tasks.

  ### Changes
  - Created `src/network.ts` with shared functions: `signToken()` and `deleteFiles()`
  - Exported `DeleteFilesResponse` type for reuse
  - Refactored `delete-files` task to use shared network module
  - Removed duplicate code from `file-deletion/index.ts