### PR TITLE
[PB-5703] feat/delete file versions

### DIFF
--- a/src/drive.ts
+++ b/src/drive.ts
@@ -233,4 +233,78 @@ export class DriveDatabase {
 
         return result.rowCount;
     }
+
+    /**
+     * Gets deleted file versions pending processing
+     * @returns Array of deleted file versions
+     */
+    async getDeletedFileVersions(): Promise<{
+        fileVersionId: string;
+        fileId: string;
+        networkFileId: string;
+        size: bigint;
+        processed: boolean;
+        enqueued: boolean;
+        createdAt: Date;
+        updatedAt: Date;
+        processedAt: Date;
+    }[]> {
+        const query = `
+            SELECT
+                file_version_id,
+                file_id,
+                network_file_id,
+                size,
+                processed,
+                enqueued,
+                created_at,
+                updated_at,
+                processed_at
+            FROM deleted_file_versions
+            WHERE processed = false AND enqueued = false
+            LIMIT 100
+        `;
+
+        const result = await this.client.query(query);
+
+        return result.rows.map(r => ({
+            fileVersionId: r.file_version_id,
+            fileId: r.file_id,
+            networkFileId: r.network_file_id,
+            size: r.size,
+            processed: r.processed,
+            enqueued: r.enqueued,
+            createdAt: r.created_at,
+            updatedAt: r.updated_at,
+            processedAt: r.processed_at,
+        }));
+    }
+
+    /**
+     * Mark file versions as enqueued for deletion
+     * @param versionIds
+     */
+    async setFileVersionsAsEnqueued(versionIds: string[]): Promise<void> {
+        const placeholders = versionIds.map((_, i) => `$${i + 1}`).join(", ");
+        const query = `
+            UPDATE deleted_file_versions
+            SET enqueued = true, enqueued_at = NOW(), updated_at = NOW()
+            WHERE file_version_id IN (${placeholders})
+        `;
+        await this.client.query(query, versionIds);
+    }
+
+    /**
+     * Mark deleted file versions as processed after successful deletion from network
+     * @param versionIds
+     */
+    async markDeletedFileVersionsAsProcessed(versionIds: string[]): Promise<void> {
+        const placeholders = versionIds.map((_, i) => `$${i + 1}`).join(", ");
+        const query = `
+            UPDATE deleted_file_versions
+            SET processed = true, processed_at = NOW(), updated_at = NOW()
+            WHERE file_version_id IN (${placeholders})
+        `;
+        await this.client.query(query, versionIds);
+    }
 }

--- a/src/drive.ts
+++ b/src/drive.ts
@@ -249,21 +249,7 @@ export class DriveDatabase {
         updatedAt: Date;
         processedAt: Date;
     }[]> {
-        const query = `
-            SELECT
-                file_version_id,
-                file_id,
-                network_file_id,
-                size,
-                processed,
-                enqueued,
-                created_at,
-                updated_at,
-                processed_at
-            FROM deleted_file_versions
-            WHERE processed = false AND enqueued = false
-            LIMIT 100
-        `;
+        const query = 'SELECT * FROM deleted_file_versions WHERE processed = false AND enqueued = false LIMIT 100';
 
         const result = await this.client.query(query);
 

--- a/src/tasks/file-version-deletion/deleted-file-versions.iterator.ts
+++ b/src/tasks/file-version-deletion/deleted-file-versions.iterator.ts
@@ -1,0 +1,38 @@
+import { DriveDatabase } from "../../drive";
+
+export class DeletedFileVersionsIterator {
+  constructor(private readonly db: DriveDatabase) {}
+
+  async * [Symbol.asyncIterator]() {
+    let rows : {
+      fileVersionId: string,
+      fileId: string,
+      networkFileId: string;
+      size: bigint,
+      processed: boolean,
+      enqueued: boolean,
+      createdAt: Date,
+      updatedAt: Date,
+      processedAt: Date,
+    }[] = [];
+    let n = 50;
+
+    do {
+      const rows = await this.db.getDeletedFileVersions();
+      if (rows.length === 0) {
+        console.log('No file versions to process, waiting 1s...');
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      } else {
+        await this.db.setFileVersionsAsEnqueued(rows.map(row => row.fileVersionId));
+        while (rows.length >= n) {
+          const chunk = rows.splice(0, n);
+          yield chunk;
+        }
+
+        if (rows.length > 0) {
+          yield rows;
+        }
+      }
+    } while (true);
+  }
+}

--- a/src/tasks/file-version-deletion/index.ts
+++ b/src/tasks/file-version-deletion/index.ts
@@ -1,0 +1,102 @@
+import { v4 } from 'uuid';
+
+import { createLogger } from '../../utils';
+import { Consumer } from '../../consumer';
+import { Producer } from '../../producer';
+import { DeletedFileVersionsIterator } from './deleted-file-versions.iterator';
+import { TaskFunction } from '../task';
+import { deleteFiles } from '../../network';
+
+const task: TaskFunction = async (
+  processType,
+  drive,
+  connection,
+) => {
+  const processId = v4();
+  const logger = createLogger(processId);
+
+  const queueName = `${process.env.TASK_TYPE}-${process.env.NODE_ENV}`;
+  const maxEnqueuedItems = process.env.TASK_DELETE_FILE_VERSIONS_PRODUCER_MAX_ENQUEUED_ITEMS;
+  const maxConcurrentItems = process.env.TASK_DELETE_FILE_VERSIONS_CONSUMER_MAX_CONCURRENT_ITEMS;
+
+  if (!maxEnqueuedItems) {
+    logger.log('Missing env var: TASK_DELETE_FILE_VERSIONS_PRODUCER_MAX_ENQUEUED_ITEMS');
+    process.exit(1);
+  }
+
+  if (!maxConcurrentItems) {
+    logger.log('Missing env var: TASK_DELETE_FILE_VERSIONS_CONSUMER_MAX_CONCURRENT_ITEMS');
+    process.exit(1);
+  }
+
+  logger.log(`params: process_type -> ${processType}, env -> ${
+    JSON.stringify({
+      maxConcurrentItems,
+      maxEnqueuedItems,
+      queueName
+    })
+  }`);
+
+
+  if (processType === 'producer') {
+    const deletedFileVersionsIterator = new DeletedFileVersionsIterator(drive.db);
+
+    return connection.createChannel().then((channel) => {
+      const producer = new Producer(
+        channel,
+        queueName as string,
+        deletedFileVersionsIterator,
+        maxEnqueuedItems ? parseInt(maxEnqueuedItems as string) : undefined,
+      );
+
+      producer.on('enqueue', (item) => {
+        logger.log(`enqueued item: + ${JSON.stringify(item)}`, 'producer');
+      });
+
+      producer.on('queue-full', () => {
+        logger.log(`queue full, waiting 1s...`, 'producer');
+      });
+
+      return producer.run();
+    });
+  } else {
+    connection.createChannel().then((channel) => {
+      const consumer = new Consumer<{
+        payload: {
+          fileVersionId: string,
+          fileId: string,
+          networkFileId: string,
+          size: bigint,
+          processed: boolean,
+          enqueued: boolean,
+          createdAt: Date,
+          updatedAt: Date,
+          processedAt: Date,
+        }[]
+      }>(
+        channel,
+        queueName as string,
+        async (task) => {
+          logger.log(`received item: + ${JSON.stringify(task)}`, 'consumer');
+
+          const networkFileIdsToDelete = task.payload.map((version) => version.networkFileId);
+
+          const res = await deleteFiles(process.env.NETWORK_GATEWAY_DELETE_FILES_ENDPOINT as string, networkFileIdsToDelete);
+          const versionIdsDeletedSuccessfully = res.message.confirmed;
+          const versionsToMarkAsProcessed = task.payload.filter((version) => versionIdsDeletedSuccessfully.includes(version.networkFileId));
+
+          await drive.db.markDeletedFileVersionsAsProcessed(versionsToMarkAsProcessed.map(v => v.fileVersionId));
+        },
+        maxConcurrentItems ? parseInt(maxConcurrentItems as string) : undefined,
+      );
+
+      consumer.on('error', ({ err, msg }) => {
+        logger.error(`error processing item: ${JSON.stringify(msg.content)}`, err, 'consumer');
+      });
+
+      consumer.run();
+    });
+  }
+}
+
+export default task;

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -2,10 +2,12 @@ import { TaskFunction } from './task';
 
 import fileDeletion from './file-deletion';
 import folderDeletion from './folder-deletion';
+import fileVersionDeletion from './file-version-deletion';
 
 export const tasks: Record<string, TaskFunction> = {
   'delete-files': fileDeletion,
   'delete-folders': folderDeletion,
+  'delete-file-versions': fileVersionDeletion,
 };
 
 export const taskTypes = Object.keys(tasks);


### PR DESCRIPTION
 ## What does this PR do?

This PR implements a background task process to automatically delete file versions from the Storj storage network when they are marked as DELETED. The task consists of a producer that queries pending deleted versions and a consumer that processes the deletion from the network.

  **Components added:**
  - **Producer**: Queries deleted_file_versions table, marks records as enqueued, and publishes to RabbitMQ queue
  - **Consumer**: Receives messages from queue, calls Network Gateway to delete from Storj, marks records as processed
  - **Database methods**: getDeletedFileVersions(), setFileVersionsAsEnqueued(), markDeletedFileVersionsAsProcessed()
  - **Network module**: Shared logic for deleting files from storage network via Network Gateway API
  - **Iterator**: DeletedFileVersionsIterator for efficient batch processing with polling

  **Refactors included:**
  - Extracted network deletion logic to shared src/network.ts module (reusable across tasks)
  - Modified delete-files task to only delete main files (versions are now handled by this new task)

  ## Why are we doing this?

File versions marked as DELETED remain in the storage network. This happens when:

  - Retention policies exceed max versions limit
  - Users manually delete specific versions
  - Plan downgrades trigger version cleanup
  - Files with multiple versions are deleted

Previously, only versions deleted as part of parent file deletion were removed from the network. This task ensures ALL deleted versions are cleaned up, regardless of deletion source.

 ## How are we doing this?

  **Producer flow:**
  1. Queries deleted_file_versions WHERE processed=false AND enqueued=false (batches of 100)
  2. Marks selected records as enqueued=true and sets enqueued_at timestamp
  3. Publishes batches to RabbitMQ queue: delete-file-versions-{environment}
  4. Polls every 1 second when no pending records

  **Consumer flow:**
  1. Receives batch from RabbitMQ queue
  2. Extracts networkFileId from each version
  3. Calls Network Gateway API: POST /delete-files with JWT authentication
  4. Processes response: marks successfully deleted versions as processed=true
  5. Sets processed_at timestamp for confirmed deletions

  **Error handling:**
  - Only marks versions as processed if confirmed by Network Gateway
  - Versions that fail deletion remain enqueued=true for retry or manual investigation
  - Consumer logs errors with full message context

  ## Should this be manually tested & how?

   **Already tested:**
  - Producer connects to PostgreSQL and RabbitMQ successfully
  - Producer queries deleted_file_versions table correctly
  - Producer marks records as enqueued=true and sets enqueued_at timestamp
  - Producer publishes messages to queue delete-file-versions-development
  - Producer enters polling loop after processing all records
  - Database trigger integration: versions marked DELETED automatically appear in queue

## Environment Variables Required

  - **TASK_DELETE_FILE_VERSIONS_PRODUCER_MAX_ENQUEUED_ITEMS**
  - **TASK_DELETE_FILE_VERSIONS_CONSUMER_MAX_CONCURRENT_ITEMS**
  - **NETWORK_GATEWAY_DELETE_FILES_ENDPOINT**
  - **TASK_TYPE**